### PR TITLE
Switch from 'Total' cost to 'Amortized' cost

### DIFF
--- a/cloudability.go
+++ b/cloudability.go
@@ -28,7 +28,7 @@ type ResultsEntry struct {
 	AccountID      string `json:"vendor_account_identifier"`
 	AccountName    string `json:"vendor_account_name"`
 	CloudProvider  string `json:"vendor"`
-	Cost           string `json:"unblended_cost"`
+	Cost           string `json:"total_amortized_cost"`
 	CostCenter     string `json:"category4"`
 	PayerAccountId string `json:"account_identifier"`
 	UsageFamily    string `json:"usage_family"`
@@ -110,8 +110,10 @@ func getCloudabilityData(configMap Configuration, options CommandLineOptions) *C
 	}
 
 	costType := *options.costTypePtr
-	if costType == "UnblendedCost" {
-		costType = "unblended_cost"
+	if costType == "AmortizedCost" {
+		costType = "total_amortized_cost"
+	} else {
+		log.Fatalf("Unexpected cost type: %q -- this requires a change to the ResultsEntry.Cost tag", costType)
 	}
 
 	qParams := cUrl.Query()

--- a/costpuller.go
+++ b/costpuller.go
@@ -56,7 +56,7 @@ func main() {
 	options := CommandLineOptions{
 		accountsFilePtr:   flag.String("accounts", "accounts.yaml", "file to read accounts list from"),
 		awsWriteTagsPtr:   flag.Bool("awswritetags", false, "write tags to AWS accounts (USE WITH CARE!)"),
-		costTypePtr:       flag.String("costtype", "UnblendedCost", `cost type to pull, one of "AmortizedCost", "BlendedCost", "NetAmortizedCost", "NetUnblendedCost", "NormalizedUsageAmount", "UnblendedCost", or "UsageQuantity"`),
+		costTypePtr:       flag.String("costtype", "AmortizedCost", `cost type to pull, one of "AmortizedCost", "BlendedCost", "NetAmortizedCost", "NetUnblendedCost", "NormalizedUsageAmount", "UnblendedCost", or "UsageQuantity"`),
 		csvfilePtr:        flag.String("csv", defaultCsvFile, "output file for csv data"),
 		debugPtr:          flag.Bool("debug", false, "outputs debug info"),
 		monthPtr:          flag.String("month", defaultMonth, `context month in format yyyy-mm`),


### PR DESCRIPTION
This PR changes the default type of cost values from "Total" cost to "Amortized" cost, which we expect to match the numbers charged to our Cost Center by Finance.

Unfortunately, given the way that Go's JSON parsing works, the change also requires updating the tag on the `Results Entry` structure field, which makes it awkward to support other cost value types, so this change also adds an error in the event that a value other than the default is used with Cloudability.